### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-#Vkontakte
+# Vkontakte
 Can be found here: https://vk.com
 
 VK (Originally VKontakte, Russian: ВКонтакте, literally "in contact") is the second biggest social network service in Europe after Facebook. It is available in several languages but popular particularly among Russian-speaking users around the world, especially in Russia, Ukraine, Azerbaijan, Kazakhstan, Moldova, Belarus, and Israel.
 
-#Build status
+# Build status
 [![Build Status](https://travis-ci.org/AndrewShmig/Vkontakte-iOS-SDK-LV.png?branch=master)](https://travis-ci.org/AndrewShmig/Vkontakte-iOS-SDK-LV)
 
-#Documentation & Examples & Etc
+# Documentation & Examples & Etc
 Additional and latest documentation, hacks and features you can find [here](https://github.com/AndrewShmig/Vkontakte-iOS-SDK-LV/tree/master/Project/Vkontakte-iOS-SDK-LV/Documentation/html).
 
 Tutorials and more details you can get [here](https://andrewshmig.github.io/Vkontakte-iOS-SDK-LV/).
 
-#Vkontakte SDK
+# Vkontakte SDK
 Feature requests can be left [here](https://github.com/AndrewShmig/Vkontakte-iOS-SDK-v2.0/issues/new).
 List of all versions can be found [here](https://github.com/AndrewShmig/Vkontakte-iOS-SDK-LV/releases).
 
@@ -19,7 +19,7 @@ You can also use [CocoaPods](https://github.com/CocoaPods/Specs/tree/master/Vkon
 
 **Author will be really appreciated to those who'll send him links on Apps or just App names which use any version of Vkontakte iOS SDK. Cheers!**
 
-#License
+# License
 Copyright (c) 2013 Andrew Shmig
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
